### PR TITLE
docs: promote why_adaswarm to the headline example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,20 @@ git clone https://github.com/AdaSwarm/AdaSwarm.git
 cd AdaSwarm
 uv sync --extra examples
 
-# 2. Run the self-contained example (trains Iris with AdaSwarm vs a standard loss)
-uv run python examples/quickstart.py
+# 2. See the two things AdaSwarm can do that plain gradient descent cannot
+uv run python examples/why_adaswarm.py
 ```
 
-Prefer a narrated, visual walkthrough with a convergence plot? Open
-[`examples/quickstart.ipynb`](examples/quickstart.ipynb) locally or
-[in Colab](https://colab.research.google.com/github/AdaSwarm/AdaSwarm/blob/main/examples/quickstart.ipynb).
+This runs a head-to-head against plain Adam on identical model/data/init and shows AdaSwarm
+(1) escaping a deceptive local minimum, and (2) training through a **non-differentiable** loss where
+Adam cannot move. Prefer a narrated, visual walkthrough with plots? Open
+[`examples/why_adaswarm.ipynb`](examples/why_adaswarm.ipynb) locally or
+[in Colab](https://colab.research.google.com/github/AdaSwarm/AdaSwarm/blob/main/examples/why_adaswarm.ipynb).
+
+> **Just want the basic API on a classic dataset?** See the Iris basic-usage example
+> ([`examples/quickstart.py`](examples/quickstart.py) /
+> [notebook](examples/quickstart.ipynb) /
+> [Colab](https://colab.research.google.com/github/AdaSwarm/AdaSwarm/blob/main/examples/quickstart.ipynb)).
 
 ## 🧠 Mental model: where AdaSwarm plugs in
 
@@ -219,10 +226,11 @@ uv sync                 # core library only
 uv sync --extra examples   # + torchvision/matplotlib/jupyter for the examples & notebook
 ```
 
-### Run the example
+### Run the examples
 
 ```bash
-uv run python examples/quickstart.py
+uv run python examples/why_adaswarm.py   # the "why it works" showcase
+uv run python examples/quickstart.py     # basic API on the Iris dataset
 ```
 
 ### Run the tests

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,15 @@
+# AdaSwarm examples
+
+| Example | What it shows | Start here if… |
+|---|---|---|
+| [`why_adaswarm.py`](why_adaswarm.py) / [`why_adaswarm.ipynb`](why_adaswarm.ipynb) | **Why AdaSwarm exists** — head-to-head vs plain Adam on (1) a deceptive multi-well loss and (2) a non-differentiable loss. | You want to see where AdaSwarm genuinely beats gradient descent. |
+| [`quickstart.py`](quickstart.py) / [`quickstart.ipynb`](quickstart.ipynb) | **Basic API** — using `adaswarm.nn.BCELoss()` with Adam on the Iris dataset. | You just want the minimal usage pattern on a classic dataset. |
+| [`main.py`](main.py) | Longer training-loop example on Iris. | You want a fuller training script. |
+
+Install the example dependencies first:
+
+```bash
+uv sync --extra examples
+```
+
+See [`docs/use-cases.md`](../docs/use-cases.md) for real-world problem classes where `SwarmLoss` fits.


### PR DESCRIPTION
## Summary

Phase 6 of the SwarmLoss plan: promote the **non-smooth showcase** to the headline example so a newcomer immediately sees *why* AdaSwarm exists.

## Changes
- **README Quickstart** now leads with `examples/why_adaswarm.py` — the head-to-head vs plain Adam (escapes a deceptive local minimum; trains through a non-differentiable loss).
- The Iris `quickstart` is kept but demoted to a "just want the basic API?" pointer.
- "Run the examples" section lists both, in priority order.
- New **`examples/README.md`** indexing the examples and their roles, and linking `docs/use-cases.md`.

Docs-only; no code changes.